### PR TITLE
Setup Bonus Tiles: Improve wording for random selection

### DIFF
--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -77,7 +77,7 @@
     },
     "bonusCards": {
       "title": "Rundenboni",
-      "take": "Mische die {count} Rundenboni und lege sie aufgedeckt nebeneinander in einer Reihe aus. Automa erhält den Rundenbonus ganz links. Wähle dann regulär einen für dich.",
+      "take": "Mische {count} zufällig ausgewählte Rundenboni und lege sie aufgedeckt nebeneinander in einer Reihe aus. Automa erhält den Rundenbonus ganz links. Wähle dann regulär einen für dich.",
       "takeTwoHumanPlayer": "Mische 4 zufällig gewählte Rundenboni und lege sie aufgedeckt nebeneinander in einer Reihe aus. Automa erhält den Rundenbonus ganz links.",
       "coins": "Legt auf die Rundenboni, die übrig geblieben sind, je 1 Geldmünze."
     }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -77,7 +77,7 @@
     },
     "bonusCards": {
       "title": "Round Bonus",
-      "take": "Shuffle the {count} Round Bonus tiles and place them face-up in a horizontal line. Give Automa the first one. Then choose your own Round Bonus tile.",
+      "take": "Shuffle {count} randomly selected Round Bonus tiles and place them face-up in a horizontal line. Give Automa the first one. Then choose your own Round Bonus tile.",
       "takeTwoHumanPlayer": "Shuffle 4 random Round Bonus tiles and place them face-up in a horizontal line. Give Automa the first one.",
       "coins": "Place 1 Coin on each of the leftover Round Bonus tiles."
     }


### PR DESCRIPTION
Instead of "Shuffle the X Round Bonus tiles" use "Shuffle {count} randomly selected Round Bonus tiles"
Updated EN+DE translation

Updated i18n keys:
```
setupGameAutoma.bonusCards.take
```