### PR TITLE
Powermongers: Improve formatting of ongoing benefit

### DIFF
--- a/src/components/turn/botAction/ActionAdvanceScienceDiscipline.vue
+++ b/src/components/turn/botAction/ActionAdvanceScienceDiscipline.vue
@@ -7,9 +7,9 @@
     <SupportInfo :bot-action="botAction" :directional-selection="true"/>
   </div>
   <div class="actionCol text-muted small">
+    <div v-if="isPowerMongers"><AppIcon type="action" name="faction-action" class="factionActionIcon"/><span v-html="t('botAction.advanceScienceDiscipline.factionPowerMongers')"></span></div>
     <ol>
       <li v-if="isDruids"><AppIcon type="action" name="faction-action" class="factionActionIcon"/><span v-html="t('botAction.advanceScienceDiscipline.factionDruids')"></span></li>
-      <li v-if="isPowerMongers"><AppIcon type="action" name="faction-action" class="factionActionIcon"/><span v-html="t('botAction.advanceScienceDiscipline.factionPowerMongers')"></span></li>
       <li v-html="t('botAction.advanceScienceDiscipline.canAdvance')"></li>
       <SendScholarTrackSelection :botAction="botAction" :navigationState="navigationState"/>
       <li v-html="t('botAction.advanceScienceDiscipline.execute.title')"></li>

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -157,7 +157,7 @@
     },
     "advanceScienceDiscipline": {
       "factionDruids": "<b>Aufsteigen in einer Disziplin: Automa setzt keinen Gelehrten ein und steigt um 2 Stufen auf</b>.",
-      "factionPowerMongers": "<b>Dauerhafte Fähigkeit: Erhältst du durch ein Automa-Gebäude min. 2 Macht, steigt Automa in 1 Disziplin um 1 Stufe auf.</b>",
+      "factionPowerMongers": "<b>Dauerhafte Fähigkeit: Erhältst du durch ein Automa-Gebäude min. 2 Macht, steigt Automa in 1 Disziplin um 1 Stufe auf:</b>",
       "canAdvance": "Automa ignoriert Disziplinen, in denen sie nicht aufsteigen kann.",
       "execute": {
         "title": "Ausführung:",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -157,7 +157,7 @@
     },
     "advanceScienceDiscipline": {
       "factionDruids": "<b>Automa advances 2 Levels in 1 Discipline (without placing a Scholar)</b>.",
-      "factionPowerMongers": "<b>Ongoing Benefit: Whenever you gain 2 or more Power via buildings, Automa advances 1 Level in a Discipline.</b>",
+      "factionPowerMongers": "<b>Ongoing Benefit: Whenever you gain 2 or more Power via buildings, Automa advances 1 Level in a Discipline:</b>",
       "canAdvance": "Automa ignores disciplines it cannot advance.",
       "execute": {
         "title": "Execute:",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -157,7 +157,7 @@
     },
     "advanceScienceDiscipline": {
       "factionDruids": "<b>El Automa avanza 2 niveles en 1 disciplina (sin colocar un erudito)</b>.",
-      "factionPowerMongers": "<b>Beneficio: Cuando ganes 2 o más poder por edificios, el Automa avanzará 1 nivel en una disciplina.</b>",
+      "factionPowerMongers": "<b>Beneficio: Cuando ganes 2 o más poder por edificios, el Automa avanzará 1 nivel en una disciplina:</b>",
       "canAdvance": "El Automa ignorará las disciplinas en las que no pueda avanzar.",
       "execute": {
         "title": "Acción:",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -157,7 +157,7 @@
     },
     "advanceScienceDiscipline": {
       "factionDruids": "<b>오토마가 1개 분야에서 2레벨 진전합니다(학자를 놓지 않고)</b>.",
-      "factionPowerMongers": "<b>지속 효과: 당신이 건물을 통해 2 이상의 파워를 얻을 때마다, 오토마가 한 분야에서 1레벨 진전합니다.</b>",
+      "factionPowerMongers": "<b>지속 효과: 당신이 건물을 통해 2 이상의 파워를 얻을 때마다, 오토마가 한 분야에서 1레벨 진전합니다:</b>",
       "canAdvance": "오토마는 진전할 수 없는 분야를 무시합니다.",
       "execute": {
         "title": "실행:",


### PR DESCRIPTION
To ensure it is clear that the discipline advancement only takes place of player actually gained 2 or more power via buildings